### PR TITLE
Fix wrong CI job identifier

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,7 +3,7 @@ name: pylint Lint
 on: [push, pull_request]
 
 jobs:
-  flake8-lint:
+  pylint:
     runs-on: ubuntu-latest
     name: Lint
     steps:


### PR DESCRIPTION
A pylint job was wrongly listed as flake8.